### PR TITLE
Remove dependency on go-pipe external library in build/ci.go.

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -17,15 +17,12 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
-
-	"github.com/b4b4r07/go-pipe"
 )
 
 var tempGoPath, tempProjectRoot string
@@ -180,9 +177,7 @@ func fetchVendoredPackages() {
 
 func generatePackagesList() (packagesToTest []string, err error) {
 
-	packagesToTestByteArr := &bytes.Buffer{}
-
-	err = pipe.Command(packagesToTestByteArr,
+	packagesToTestByteArr, err := pipe(
 		exec.Command("go", "list", "./..."),
 		exec.Command("grep", "-v", "-e", "build", "-e", "contract_store", "-e", "mocks", "-e", "walkthrough"),
 	)

--- a/build/pipe.go
+++ b/build/pipe.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+func pipe(CommandsToExecute ...*exec.Cmd) (outputBuff bytes.Buffer, err error) {
+
+	stderrBuff, stdoutBuff, stdinBuff := &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}
+
+	for _, cmd := range CommandsToExecute {
+		cmd.Stdin = stdinBuff
+		cmd.Stderr = stderrBuff
+		cmd.Stdout = stdoutBuff
+
+		err = cmd.Run()
+
+		if err != nil {
+			return *stderrBuff, err
+		}
+
+		stdinBuff = stdoutBuff
+	}
+
+	return *stdoutBuff, nil
+}


### PR DESCRIPTION
The project uses Makefile to fetch dependencies, build and test the packages for continuous integration environments. Running make on a fresh machine returns error due to a missing dependency of the build package.

This pull request will remove the dependency on the external library in build/ci.go by implementing the same functionality in the build package itself.

Signed-off-by: Manoranjith <ponraj.manoranjitha@in.bosch.com>