### PR TITLE
Modify command pipe implementation in build package.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -22,6 +22,7 @@
 
 Robert Bosch GmbH
     Daniel Kunz <daniel.kunz@de.bosch.com>
+    Manoranjith <ponraj.manoranjitha@in.bosch.com>
 
 Robert Bosch LLC
 

--- a/NOTICE
+++ b/NOTICE
@@ -22,5 +22,6 @@
 
 Robert Bosch GmbH
     Daniel Kunz <daniel.kunz@de.bosch.com>
+
 Robert Bosch LLC
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -55,7 +55,7 @@ func main() {
 
 	packagesList, err := generatePackagesList()
 	if err != nil {
-		fmt.Printf("Error generating package list : %s", err)
+		fmt.Printf("Error generating package list : %s\n", err)
 		os.Exit(1)
 	}
 

--- a/build/pipe.go
+++ b/build/pipe.go
@@ -1,3 +1,19 @@
+// Copyright (c) 2019 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository at
+//     https://github.com/direct-state-transfer/dst-go
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -10,6 +26,9 @@ func pipe(CommandsToExecute ...*exec.Cmd) (outputBuff bytes.Buffer, err error) {
 	stderrBuff, stdoutBuff, stdinBuff := &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}
 
 	for _, cmd := range CommandsToExecute {
+
+		stdoutBuff = &bytes.Buffer{}
+
 		cmd.Stdin = stdinBuff
 		cmd.Stderr = stderrBuff
 		cmd.Stdout = stdoutBuff

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -138,12 +138,6 @@
 			"revisionTime": "2019-04-26T09:22:21Z"
 		},
 		{
-			"checksumSHA1": "aR8giSwNg7ogfWoUuEqkqmN/HRc=",
-			"path": "github.com/b4b4r07/go-pipe",
-			"revision": "ed1c7948fefc784c9e562b891ee421bb0d803811",
-			"revisionTime": "2019-05-10T19:03:01Z"
-		},
-		{
 			"checksumSHA1": "gZQ6HheWahvZzIc3phBnOwoWHjE=",
 			"origin": "github.com/ethereum/go-ethereum/vendor/github.com/btcsuite/btcd/btcec",
 			"path": "github.com/btcsuite/btcd/btcec",


### PR DESCRIPTION
Previously command pipe returns a buffer with the output of all commands.
Now it returns only the output of the last command.

Remove unused dependency - "github.com/b4b4r07/go-pipe" from vendor.json.

Signed-off-by: Manoranjith <ponraj.manoranjitha@in.bosch.com>