### PR TITLE
Remove duplication from Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           name: Run unit short tests
           command: |
             trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
-            make ciTest testOpts="-v -short" | tee ${TEST_RESULTS}/go-test.out
+            make ciTest BUILDOPTS="-v -short" | tee ${TEST_RESULTS}/go-test.out
       - store_test_results:
           path: /tmp/test-results
 
@@ -49,7 +49,7 @@ jobs:
       - run:
           name: Run walktthrough with simulated backend
           command: |
-            make ciRunWalkthrough walkthroughOpts="--simulated_backend"
+            make ciRunWalkthrough BUILDOPTS="--simulated_backend"
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -78,13 +78,15 @@ From the local workspace run the following command to clone the dst-go project.
 git clone https://github.com/direct-state-transfer/dst-go.git
 ```
 
-The available make files can be used to build dst-go from source.
+The available make file can be used to build dst-go from source.
 The following commands can be executed from the root repository of the project.
 (~/LOCAL_WORKSPACE/dst-go/)
 
 ```bash
+#To get a list of available build targets
+make help
 #To fetch dependencies and install dst-go
-make
+make install
 ```
 
 On successful run, the binary will be available at ~/LOCAL_WORKSPACE/dst-go/build/workspace_/bin
@@ -162,14 +164,14 @@ The following make commands are available to run the walkthrough sequence.
 
 ```bash
 #To run walkthrough with real backend
-make runWalkthrough walkthroughOpts="--real_backend"
+make runWalkthrough BUILDOPTS="--real_backend"
 
 #To run with simulated backend
 #This will work with the default configuration in testdata
-make runWalkthrough walkthroughOpts="--simulated_backend"
+make runWalkthrough BUILDOPTS="--simulated_backend"
 
 #Multiple options can also be passed as shown below.
-make runWalkthrough backend=real walkthroughOpts="--simulated_backend --dispute --ch_message_print"
+make runWalkthrough BUILDOPTS="--simulated_backend --dispute --ch_message_print"
 ```
 
 ### Testing
@@ -185,7 +187,7 @@ make test
 # option as shown below.
 # Some flags will be enabled by default (-cover and cache=1). Output is
 # non verbose by default.
-make test testOpts="-v -short"
+make test BUILDOPTS="-v -short"
 ```
 
 #### Performing lint

--- a/build/ci.go
+++ b/build/ci.go
@@ -59,6 +59,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	// documentation of commands in doc.go
 	switch os.Args[1] {
 	case "fetchDependencies":
 		fetchVendoredPackages()

--- a/build/doc.go
+++ b/build/doc.go
@@ -14,17 +14,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// build implements commands that will be called from the continuous integration scripts.
-// The commands are also used by makefile to build the project on systems where setting up
-// a go development environment or using existing one for this project is not desirable.
-//
-//Available commands are
-//	fetchDependencies		-- fetches all needed dependencies
-//	install				-- fetch dependencies and installs the dst-go software.
-//	ciInstall			-- installs the dst-go software
-//	lint				-- runs meta-linter with configuration at linterConfig.json.
-//	test				-- fetch dependencies and runs unit tests, all flags of "go test" command can be used.
-//	ciTest				-- runs unit tests, all flags of "go test" command can be used.
-//	runWalkthrough			-- fetch dependencies, builds and runs the walkthrough. Specify "simulated" or "real" backend.
-//	ciRunWalkthrough		-- builds and runs the walkthrough. Specify "simulated" or "real" backend.
+/*
+build implements commands that will be called from the continuous integration scripts.
+The commands are also used by makefile to build the project on systems where setting up
+a go development environment or using existing one for this project is not desirable.
+
+Available commands are:
+
+	install        -- install the dst-go software
+	lint           -- run meta-linter with configuration linterConfig.json
+	test           -- run unit tests, with options as in "go test" command
+	runWalkthrough -- build and run walkthrough. Behavior is configurable with
+	                  options such as "--simulated_backend", "--real_backend",
+	                  etc.
+
+	fetchDependencies -- fetch all dependencies
+	ciInstall         -- as `install` but without fetching dependencies
+	ciTest            -- as `test` but without fetching dependencies
+	ciRunWalkthrough  -- as `runWalkthrough` but without fetching dependencies
+
+*/
 package main


### PR DESCRIPTION
Refactor Makefile to remove duplication:
- all targets within the Makefile had the same structure with some setup
  and teardown around a call forwarding the target (along with optional
  arguments) to build/build. Replace the different make targets with a
  generic one, and add a help target to provide usage information.
- Both the Makefile and the build component provide the same build
  targets (and possible the same documentation). Instead of having to
  keep that in sync, refactor the Makefile to collect the necessary
  information from the build component and dynamically configure make
  targets and help message.