### PR TITLE
Fix build fail with msg "Govendor sync failed..."

### DIFF
--- a/build/setEnv.sh
+++ b/build/setEnv.sh
@@ -24,8 +24,8 @@ fi
     fi
    
     # Set up the environment to use the workspace.
-    GOPATH="$tempGoPath"
-    export GOPATH
+    export GOPATH="$tempGoPath"
+    export GOBIN=""
 
     # Change Dir
     cd "$tempDir/dst-go"


### PR DESCRIPTION
Build using makefile fails with the above error message when it is
triggered after clean checkout and GOBIN environment variable is to
"non empty path" with no govendor, gometalinter binaries.This is fixed.
Also the code in build/setEnv.sh is formatted.

Fixes #7

Signed-off-by: Manoranjith <ponraj.manoranjitha@in.bosch.com>