### PR TITLE
Fix typo in copyright header

### DIFF
--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/blockchain/config_for_test.go
+++ b/blockchain/config_for_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/blockchain/config_test.go
+++ b/blockchain/config_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/blockchain/doc.go
+++ b/blockchain/doc.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/blockchain/manager.go
+++ b/blockchain/manager.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/blockchain/manager_test.go
+++ b/blockchain/manager_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/build/ci.go
+++ b/build/ci.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/build/doc.go
+++ b/build/doc.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/build/pipe.go
+++ b/build/pipe.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/adapter_factory.go
+++ b/channel/adapter_factory.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/adapter_factory_test.go
+++ b/channel/adapter_factory_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/adapter_websocket.go
+++ b/channel/adapter_websocket.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/adapter_websocket_test.go
+++ b/channel/adapter_websocket_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/config.go
+++ b/channel/config.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/config_for_test.go
+++ b/channel/config_for_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/config_test.go
+++ b/channel/config_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/doc.go
+++ b/channel/doc.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/manager.go
+++ b/channel/manager.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/manager_test.go
+++ b/channel/manager_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/messages.go
+++ b/channel/messages.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/messages_test.go
+++ b/channel/messages_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/offchain_primitives.go
+++ b/channel/offchain_primitives.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/offchain_primitives_test.go
+++ b/channel/offchain_primitives_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/config/config_for_test.go
+++ b/config/config_for_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/config/doc.go
+++ b/config/doc.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/config/lookup.go
+++ b/config/lookup.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/config/lookup_test.go
+++ b/config/lookup_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/config/version.go
+++ b/config/version.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/config/version_test.go
+++ b/config/version_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dst-go/config.go
+++ b/dst-go/config.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dst-go/config_for_test.go
+++ b/dst-go/config_for_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dst-go/doc.go
+++ b/dst-go/doc.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dst-go/main.go
+++ b/dst-go/main.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dst-go/main_test.go
+++ b/dst-go/main_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dst-go/session.go
+++ b/dst-go/session.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/adapter/config_for_test.go
+++ b/ethereum/adapter/config_for_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/adapter/doc.go
+++ b/ethereum/adapter/doc.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/adapter/ethereum.go
+++ b/ethereum/adapter/ethereum.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/adapter/ethereum_test.go
+++ b/ethereum/adapter/ethereum_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/contract/VPC.go
+++ b/ethereum/contract/VPC.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/contract/config_for_test.go
+++ b/ethereum/contract/config_for_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/contract/contract.go
+++ b/ethereum/contract/contract.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/contract/contract_store/generate.go
+++ b/ethereum/contract/contract_store/generate.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/contract/contract_test.go
+++ b/ethereum/contract/contract_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/contract/doc.go
+++ b/ethereum/contract/doc.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/contract/types.go
+++ b/ethereum/contract/types.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/contract/types_test.go
+++ b/ethereum/contract/types_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/keystore/config.go
+++ b/ethereum/keystore/config.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/keystore/config_for_test.go
+++ b/ethereum/keystore/config_for_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/keystore/crypto.go
+++ b/ethereum/keystore/crypto.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/keystore/crypto_test.go
+++ b/ethereum/keystore/crypto_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/keystore/doc.go
+++ b/ethereum/keystore/doc.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/keystore/keystore.go
+++ b/ethereum/keystore/keystore.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/keystore/keystore_test.go
+++ b/ethereum/keystore/keystore_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/types/doc.go
+++ b/ethereum/types/doc.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/types/types.go
+++ b/ethereum/types/types.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ethereum/types/types_test.go
+++ b/ethereum/types/types_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identity/config.go
+++ b/identity/config.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identity/config_for_test.go
+++ b/identity/config_for_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identity/config_test.go
+++ b/identity/config_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identity/doc.go
+++ b/identity/doc.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identity/manager.go
+++ b/identity/manager.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identity/signature_ethereum.go
+++ b/identity/signature_ethereum.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identity/signature_ethereum_test.go
+++ b/identity/signature_ethereum_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/log/config_for_test.go
+++ b/log/config_for_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/log/doc.go
+++ b/log/doc.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/walkthrough/doc.go
+++ b/walkthrough/doc.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/walkthrough/main.go
+++ b/walkthrough/main.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/walkthrough/real_blockchain.go
+++ b/walkthrough/real_blockchain.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/walkthrough/simulated_blockchain.go
+++ b/walkthrough/simulated_blockchain.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 - for information on the respective copyright owner
 // see the NOTICE file and/or the repository at
-//     https://github.com/direct-state-transfer/dst-go/NOTICE
+// https://github.com/direct-state-transfer/dst-go
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
The copyright header is supposed to link to the repo, i.e. the commit history, for information on the copyright owners not the NOTICE file in the repo.