### PR TITLE
Move linting jobs from golangci.com to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       - image: circleci/golang:1.12.7-stretch
         environment:
             GO111MODULE: "on"
-    working_directory: /go/src/github.com/direct-state-transfer/dst-go
+    working_directory: ~/dst-go
     steps:
       - checkout
       - run:
@@ -16,7 +16,23 @@ jobs:
       - save_cache:
           key: dst-go-{{ .Branch }}-{{ .Revision }}
           paths:
-            - /go/src/github.com/direct-state-transfer/dst-go
+            - ~/dst-go
+            - /go/pkg
+
+  lint:
+    docker:
+      - image: circleci/golang:1.12.7-stretch
+    environment:
+      GO111MODULE: "on"
+    working_directory: ~/dst-go
+    steps:
+      - restore_cache:
+          keys:
+            - dst-go-{{ .Branch }}-{{ .Revision }}
+      - run:
+          name: Run linter
+          command: |
+            make lint
 
   unit_tests_short:
     docker:
@@ -24,7 +40,7 @@ jobs:
     environment:
       GO111MODULE: "on"
       TEST_RESULTS: /tmp/test-results
-    working_directory: /go/src/github.com/direct-state-transfer/dst-go
+    working_directory: ~/dst-go
     steps:
       - run: mkdir -p $TEST_RESULTS
       - restore_cache:
@@ -46,13 +62,13 @@ jobs:
       - image: circleci/golang:1.12.7-stretch
     environment:
       GO111MODULE: "on"
-    working_directory: /go/src/github.com/direct-state-transfer/dst-go
+    working_directory: ~/dst-go
     steps:
       - restore_cache:
           keys:
             - dst-go-{{ .Branch }}-{{ .Revision }}
       - run:
-          name: Run walktthrough with simulated backend
+          name: Run walkthrough with simulated backend
           command: |
             make ciRunWalkthrough BUILDOPTS="--simulated_backend"
 
@@ -61,9 +77,13 @@ workflows:
   build-and-test:
     jobs:
       - checkout_deps
+      - lint:
+          requires:
+            - checkout_deps
       - unit_tests_short:
           requires:
             - checkout_deps
       - walkthrough_simulated:
           requires:
+            - checkout_deps
             - unit_tests_short

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Direct State Transfer - Go implementation (DST-GO)
 
+| Develop | Master |
+| :----: | :-----: |
+| [![CircleCI](https://circleci.com/gh/direct-state-transfer/dst-go/tree/develop.svg?style=shield)](https://circleci.com/gh/direct-state-transfer/dst-go/tree/develop) | [![CircleCI](https://circleci.com/gh/direct-state-transfer/dst-go/tree/master.svg?style=shield)](https://circleci.com/gh/direct-state-transfer/dst-go/tree/master) |
+
 Direct State Transfer (DST) is an open source project that aims to
 increase blockchain transaction throughput by using just a handful of
 main chain transactions to move an entire peer-to-peer network of

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Direct State Transfer - Go implementation (DST-GO)
 
-| Develop | Master |
-| :----: | :-----: |
-| [![CircleCI](https://circleci.com/gh/direct-state-transfer/dst-go/tree/develop.svg?style=shield)](https://circleci.com/gh/direct-state-transfer/dst-go/tree/develop) | [![CircleCI](https://circleci.com/gh/direct-state-transfer/dst-go/tree/master.svg?style=shield)](https://circleci.com/gh/direct-state-transfer/dst-go/tree/master) |
-
 Direct State Transfer (DST) is an open source project that aims to
 increase blockchain transaction throughput by using just a handful of
 main chain transactions to move an entire peer-to-peer network of

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/ethereum/go-ethereum v1.8.20
 	github.com/fatih/color v0.0.0-20181010231311-3f9d52f7176a
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gorilla/websocket v0.0.0-20190306004257-0ec3d1bd7fe5
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/huin/goupnp v1.0.0 // indirect
@@ -21,8 +20,6 @@ require (
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/miguelmota/go-solidity-sha3 v0.0.0-20190405010754-9010f21d6cc1
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/rjeczalik/notify v0.9.2 // indirect
 	github.com/rs/cors v1.7.0 // indirect
@@ -36,4 +33,5 @@ require (
 	golang.org/x/net v0.0.0-20190912160710-24e19bdeb0f2
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
+	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,7 @@ github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
+github.com/prometheus/prometheus v2.5.0+incompatible h1:7QPitgO2kOFG8ecuRn9O/4L9+10He72rVRJvMXrE9Hg=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
@@ -252,6 +253,8 @@ gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHN
 gopkg.in/redis.v4 v4.2.4/go.mod h1:8KREHdypkCEojGKQcjMqAODMICIVwZAONWq8RowTITA=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/urfave/cli.v1 v1.20.0 h1:NdAVW6RYxDif9DhDHaAortIu956m2c0v+09AZBPTbE0=
+gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
- GolangCI.com is closing down (#28), hence the Job for linting the code
is moved.

Resolves #28

Signed-off-by: Manoranjith <ponraj.manoranjitha@in.bosch.com>